### PR TITLE
First `GET /accounts` endpoint with test data

### DIFF
--- a/Sources/App/Data/Accounts.swift
+++ b/Sources/App/Data/Accounts.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+let Accounts = [
+    Account(id: UUID().uuidString, type: .bank, balance: Int.random(in: 1..<10000)),
+    Account(id: UUID().uuidString, type: .investing, balance: Int.random(in: 1..<10000)),
+    Account(id: UUID().uuidString, type: .investing, balance: Int.random(in: 1..<10000)),
+    Account(id: UUID().uuidString, type: .highInterestSavings, balance: Int.random(in: 1..<10000)),
+    Account(id: UUID().uuidString, type: .bank, balance: Int.random(in: 1..<10000)),
+    Account(id: UUID().uuidString, type: .bank, balance: Int.random(in: 1..<10000)),
+    Account(id: UUID().uuidString, type: .highInterestSavings, balance: Int.random(in: 1..<10000))
+]
+

--- a/Sources/App/Models/Account.swift
+++ b/Sources/App/Models/Account.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Vapor
+
+enum AccountType: String, Content {
+    case bank = "bank"
+    case investing = "investing"
+    case highInterestSavings = "high interest savings"
+}
+
+
+struct Account: Content {
+    var id: String
+    var type: AccountType
+    var balance: Int
+}
+

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -1,14 +1,7 @@
-import Fluent
 import Vapor
 
 func routes(_ app: Application) throws {
-    app.get { req async in
-        "It works!"
+    app.get("accounts") { req -> [Account] in
+        return Accounts
     }
-
-    app.get("hello") { req async -> String in
-        "Hello, world!"
-    }
-
-    try app.register(collection: TodoController())
 }


### PR DESCRIPTION
Responding with test data, using only the route handler, as the first endpoint :)

To test, build the project with `vapor build && vapor run` (or run it in Xcode). Make a `GET` request to `http://127.0.0.1:8080/accounts` and the response should be something like:

```json
[
    {
        "id": "CCB1EA16-9645-4591-97AE-FFDE6E9CC1AF",
        "type": "bank",
        "balance": 6363
    },
    {
        "id": "27B7836C-E41B-4ED8-B3C1-825E221AFF45",
        "type": "investing",
        "balance": 2296
    },
    {
        "id": "E3500043-F405-4999-ACD7-DF43E1FF9E7E",
        "type": "investing",
        "balance": 3716
    },
    {
        "id": "E923E852-0D19-4209-9B1D-F36271C74346",
        "type": "high interest savings",
        "balance": 1473
    },
    {
        "id": "F595EDDB-3E01-48FE-B07A-ADF7701EFA58",
        "type": "bank",
        "balance": 9717
    },
    {
        "id": "D8FAFC66-E09C-4C5D-89B2-8A478349B0E5",
        "type": "bank",
        "balance": 7300
    },
    {
        "id": "54B51A31-406A-4A3A-B924-57A96922A464",
        "type": "high interest savings",
        "balance": 7962
    }
]
```