### PR TITLE
Add enum for path and more standard method name for GET list call

### DIFF
--- a/Sources/App/Controllers/AccountsController.swift
+++ b/Sources/App/Controllers/AccountsController.swift
@@ -2,10 +2,11 @@ import Vapor
 
 struct AccountsController: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
-        routes.get("accounts", use: getAllHandler)
+        routes.get(AccountEndpoints.accounts.path, use: list)
     }
     
-    func getAllHandler(_ req: Request) -> [Account] {
+    func list(_ req: Request) -> [Account] {
+        print(AccountEndpoints.accounts.path)
         return Accounts
     }
 

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -1,9 +1,21 @@
 import Vapor
 
+public enum AccountEndpoints: String {
+    // MARK:- Account Endpoints
+    case accounts = "accounts"
+   
+    var path: PathComponent {
+        return PathComponent(
+            stringLiteral: self.rawValue
+        )
+    }
+}
+
 func routes(_ app: Application) throws {
     let accountsController = AccountsController()
+    print(AccountEndpoints.accounts.path)
     
-    app.get("accounts", use: accountsController.getAllHandler)
+    app.get(AccountEndpoints.accounts.path, use: accountsController.list)
     
     try app.register(collection: accountsController)
 }


### PR DESCRIPTION
To test, build the project with `vapor build && vapor run` (or run it in Xcode). Make a `GET` request to `http://127.0.0.1:8080/accounts` and the response should be something like:

```json
[
    {
        "id": "CCB1EA16-9645-4591-97AE-FFDE6E9CC1AF",
        "type": "bank",
        "balance": 6363
    },
    {
        "id": "27B7836C-E41B-4ED8-B3C1-825E221AFF45",
        "type": "investing",
        "balance": 2296
    },
    {
        "id": "E3500043-F405-4999-ACD7-DF43E1FF9E7E",
        "type": "investing",
        "balance": 3716
    },
    {
        "id": "E923E852-0D19-4209-9B1D-F36271C74346",
        "type": "high interest savings",
        "balance": 1473
    },
    {
        "id": "F595EDDB-3E01-48FE-B07A-ADF7701EFA58",
        "type": "bank",
        "balance": 9717
    },
    {
        "id": "D8FAFC66-E09C-4C5D-89B2-8A478349B0E5",
        "type": "bank",
        "balance": 7300
    },
    {
        "id": "54B51A31-406A-4A3A-B924-57A96922A464",
        "type": "high interest savings",
        "balance": 7962
    }
]
```